### PR TITLE
Add enemy knockback effect and weapon tag

### DIFF
--- a/Assets/Prefabs/PlayerV2.prefab
+++ b/Assets/Prefabs/PlayerV2.prefab
@@ -102,8 +102,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   horizontalSpeed: 9
   verticalSpeed: 9
+  dodgeFactor: 3.5
   acceleration: 75
   deceleration: 70
+  dodgeCoolDownTime: 10
+  maxDodgeBoosts: 3
+  dodgeLength: 0.5
 --- !u!50 &7300793082100157938
 Rigidbody2D:
   serializedVersion: 4
@@ -147,8 +151,8 @@ HingeJoint2D:
     m_MaximumMotorForce: 10000
   m_UseLimits: 1
   m_AngleLimits:
-    m_LowerAngle: -90
-    m_UpperAngle: 90
+    m_LowerAngle: -85
+    m_UpperAngle: 45
 --- !u!70 &2047311166149304007
 CapsuleCollider2D:
   m_ObjectHideFlags: 0
@@ -429,5 +433,5 @@ HingeJoint2D:
     m_MaximumMotorForce: 10000
   m_UseLimits: 1
   m_AngleLimits:
-    m_LowerAngle: 0
-    m_UpperAngle: 180
+    m_LowerAngle: -20
+    m_UpperAngle: 90

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -232,6 +232,10 @@ PrefabInstance:
       propertyPath: m_TagString
       value: Player
       objectReference: {fileID: 0}
+    - target: {fileID: 2235314057051779445, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_TagString
+      value: Weapon
+      objectReference: {fileID: 0}
     - target: {fileID: 3004014602359645400, guid: 77767a00023585efc822725add655cd7, type: 3}
       propertyPath: m_SortingLayer
       value: 1
@@ -244,6 +248,26 @@ PrefabInstance:
       propertyPath: m_SortingLayerID
       value: 519901987
       objectReference: {fileID: 0}
+    - target: {fileID: 3346809765117095502, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_Constraints
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4253273602517231103, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_Anchor.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4253273602517231103, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_ConnectedAnchor.x
+      value: -0.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4253273602517231103, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_AngleLimits.m_LowerAngle
+      value: -85
+      objectReference: {fileID: 0}
+    - target: {fileID: 4253273602517231103, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_AngleLimits.m_UpperAngle
+      value: 85
+      objectReference: {fileID: 0}
     - target: {fileID: 4317085768207586529, guid: 77767a00023585efc822725add655cd7, type: 3}
       propertyPath: m_ConnectedAnchor.x
       value: -0.5000005
@@ -251,6 +275,10 @@ PrefabInstance:
     - target: {fileID: 4317085768207586529, guid: 77767a00023585efc822725add655cd7, type: 3}
       propertyPath: m_ConnectedAnchor.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4317085768207586529, guid: 77767a00023585efc822725add655cd7, type: 3}
+      propertyPath: m_AngleLimits.m_LowerAngle
+      value: -25
       objectReference: {fileID: 0}
     - target: {fileID: 5887373266890729744, guid: 77767a00023585efc822725add655cd7, type: 3}
       propertyPath: m_RootOrder
@@ -310,6 +338,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 77767a00023585efc822725add655cd7, type: 3}
+--- !u!1 &313292396 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2235314057051779445, guid: 77767a00023585efc822725add655cd7, type: 3}
+  m_PrefabInstance: {fileID: 208380587}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &313292402
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 313292396}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1 &411589471
 GameObject:
   m_ObjectHideFlags: 0
@@ -1648,6 +1707,25 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1078368093 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7400595517385289058, guid: 9fef7c11c2a5f7b49b61a1537404ba1b, type: 3}
+  m_PrefabInstance: {fileID: 7400595518264194873}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1078368099
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1078368093}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aea4c0f1db8754c3892cc0e1129a50ec, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  health: 30
+  knockback: 0.6
 --- !u!1 &1126412687
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EnemyBase.cs
+++ b/Assets/Scripts/EnemyBase.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EnemyBase : MonoBehaviour
+{
+    [SerializeField, Tooltip("Enemy Health (hitpoints)")]
+    int health = 15;
+    [SerializeField, Tooltip("Knockback Force")]
+    float knockback = 0.6f;
+
+    Rigidbody2D rigidBody;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        rigidBody = GetComponent<Rigidbody2D>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    // We use OnTriggerEnter2D instead of OnCollisionEnter2D because the player hand is set to "isTrigger"
+    private void OnTriggerEnter2D(Collider2D col) 
+    {
+        // check to see what we just got hit with
+        if (col.tag == "Weapon")
+        {
+            // add a knockback effect
+            StartCoroutine(FakeAddForceMotion(knockback));
+
+            // take damage (perhaps based on weapon type)
+            
+        }     
+    }
+
+    // This function adds a fake force to a Kinematic body
+    IEnumerator FakeAddForceMotion(float forceAmount)
+    {
+        float i = 0.01f;
+        while (forceAmount > i)
+        {
+            rigidBody.velocity = new Vector2(forceAmount / i, rigidBody.velocity.y); // !! For X axis positive force
+            i = i + Time.deltaTime;
+            yield return new WaitForEndOfFrame();      
+        }
+        rigidBody.velocity = Vector2.zero;
+        yield return null;
+    }
+}

--- a/Assets/Scripts/EnemyBase.cs.meta
+++ b/Assets/Scripts/EnemyBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aea4c0f1db8754c3892cc0e1129a50ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/EnemyBehavior.cs
+++ b/Assets/Scripts/EnemyBehavior.cs
@@ -27,7 +27,7 @@ public class EnemyBehavior : MonoBehaviour
         foreach (Collider2D hit in hits)
         {
             // Ignore our own collider.
-            if (hit.tag == "Enemy")
+            if (hit.tag == "Enemy" || hit.tag == "Weapon")
                 continue;
  
             ColliderDistance2D colliderDistance = hit.Distance(capsuleCollider);

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -7,16 +7,12 @@ public class PlayerMovement : MonoBehaviour
 {
     [SerializeField, Tooltip("Max horizontal speed, in units per second, that the character moves.")]
     float horizontalSpeed = 3;
- 
     [SerializeField, Tooltip("Max vertical speed, in units per second, that the character moves.")]
     float verticalSpeed = 3;
-    
     [SerializeField, Tooltip("Dodge Speed Factor, how many times faster is a dodge move")]
     float dodgeFactor = 3.5f;
- 
     [SerializeField, Tooltip("Acceleration while grounded.")]
     float acceleration = 75;
- 
     [SerializeField, Tooltip("Deceleration applied when character is grounded and not attempting to move.")]
     float deceleration = 70;
     [SerializeField, Tooltip("Cooldown Timer before you get your dodge boosts back")]
@@ -24,8 +20,8 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField, Tooltip("Max Number of Dodge Boosts")]
     int maxDodgeBoosts = 3;
     [SerializeField, Tooltip("Length in Time a Dodge boost lasts")]
+
     public float dodgeLength = 0.5f;
- 
     float horizontalInput;
     float verticalInput;
  
@@ -36,9 +32,7 @@ public class PlayerMovement : MonoBehaviour
  
     private float mulFactor = 1;
     private CapsuleCollider2D capsuleCollider;
- 
     private Vector2 velocity;
- 
  
     private void Awake()
     {      
@@ -115,7 +109,6 @@ public class PlayerMovement : MonoBehaviour
             }
         }
     }
- 
  
     /*
     This function freezes the character's ability to dodge after a given number of dodges. 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -5,6 +5,7 @@ TagManager:
   serializedVersion: 2
   tags:
   - Enemy
+  - Weapon
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
When the player's weapon hits an enemy, it produces a "knockback" effect.  Added a simple coroutine function that simulates a force being added to the enemy kinematic rigidbody.

Also added an "EnemyBase" script that contains the knockback effect and has the enemy's base stats (currently health).